### PR TITLE
Allow URLs in FFmpeg concat

### DIFF
--- a/lib/videoconcat.js
+++ b/lib/videoconcat.js
@@ -45,7 +45,7 @@ module.exports = function (spec) {
   function concatClips(args) {
 
     return new Promise((resolve, reject) => {
-      let child = shelljs.exec(`ffmpeg -f concat -i ${args.fileList} -c copy ${outputFileName}`, { async: true, silent: spec.silent });
+      let child = shelljs.exec(`ffmpeg -f concat -safe 0 -protocol_whitelist file,http,https,tcp,tls,crypto -i ${args.fileList} -c copy ${outputFileName}`, { async: true, silent: spec.silent });
 
       child.on('exit', (code, signal) => {
 


### PR DESCRIPTION
Added to FFmpeg concat demuxer `-safe 0 -protocol_whitelist file,http,https,tcp,tls,crypto`.
