### PR TITLE
Fix command injection via shell-interpolated file names (use execFile)

### DIFF
--- a/lib/videoconcat.js
+++ b/lib/videoconcat.js
@@ -58,7 +58,12 @@ module.exports = function (spec) {
   function concatClips(args) {
     const overwrite = handleOverwrite();
     return new Promise((resolve, reject) => {
-      let child = shelljs.exec(`${spec.ffmpeg_path} -f concat -safe 0 -protocol_whitelist file,http,https,tcp,tls,crypto -i ${args.fileList} -c copy ${outputFileName} ${overwrite}`, { async: true, silent: spec.silent });
+      // Build argv explicitly and run WITHOUT a shell, so file names / paths can never be
+      // interpreted as shell syntax (command injection via .output() / clip names / ffmpeg_path).
+      const ffArgs = ['-f', 'concat', '-safe', '0', '-protocol_whitelist',
+        'file,http,https,tcp,tls,crypto', '-i', args.fileList, '-c', 'copy', outputFileName];
+      if (overwrite) ffArgs.push(overwrite);
+      let child = require('child_process').execFile(spec.ffmpeg_path, ffArgs);
 
       child.on('exit', (code, signal) => {
 

--- a/lib/videocut.js
+++ b/lib/videocut.js
@@ -94,9 +94,10 @@ module.exports = function videoCut(spec) {
 	  return new Promise((resolve, reject) => {
 
 	    let commandQuery =
-	      `${spec.ffmpeg_path} -i ${args.fileName} -ss ${args.startTime} -t ${args.duration} ${cutFileName} -y`;
+	      ['-i', String(args.fileName), '-ss', String(args.startTime), '-t', String(args.duration), String(cutFileName), '-y'];
 
-	    let child = shelljs.exec(commandQuery, { async: true, silent: spec.silent });
+	    // Run WITHOUT a shell: argv elements are literal, never parsed as shell syntax.
+	    let child = require('child_process').execFile(spec.ffmpeg_path, commandQuery);
 
 	    child.on('exit', (code, signal) => {
 


### PR DESCRIPTION
## Security issue

`concat` (`lib/videoconcat.js`) and `cut` (`lib/videocut.js`) build the ffmpeg command as a **string** and run it through `shelljs.exec`, which executes via a shell. Consumer-supplied values are interpolated **unescaped**:

- `outputFileName` — set by the public `.output(fileName)` API
- the input clip path (`args.fileName` in `cut`)
- `spec.ffmpeg_path`

so any shell metacharacters in those values are executed. A consumer that derives, say, an output filename from user input is exposed to arbitrary command execution (CWE-78).

### Repro (using only the documented API)

```js
const { concat } = require('video-stitch');
concat()
  .clips([{ fileName: '/tmp/a.mp4' }])
  .output('out.mp4; touch PWNED')   // user-influenced output name
  .concat();
// shelljs runs:  ffmpeg ... -c copy out.mp4; touch PWNED   ->  PWNED is created
```

I confirmed this on the current published version (`1.7.1`).

## Fix

Don't build a shell string — pass an **argv array** to `child_process.execFile(spec.ffmpeg_path, [...])`. Arguments are then passed literally and never parsed as shell syntax, which eliminates the injection while keeping behavior identical for valid inputs. I verified the same PoC no longer executes the injected command after this change, and the modules load/run unchanged.

Happy to adjust style/approach however you prefer — and glad to share the full write-up privately if useful. Thanks for maintaining video-stitch!