### PR TITLE
Remove obsolete shelljs dependency and fix zero-start cuts

### DIFF
--- a/lib/videoconcat.js
+++ b/lib/videoconcat.js
@@ -3,7 +3,6 @@
 let tmp = require('tmp');
 let fext = require('file-extension');
 let fs = require('fs');
-let shelljs = require('shelljs');
 let _ = require('lodash');
 
 module.exports = function (spec) {

--- a/lib/videocut.js
+++ b/lib/videocut.js
@@ -4,7 +4,6 @@ let _ = require('lodash');
 let moment = require('moment');
 require('moment-duration-format');
 let tmp = require('tmp');
-let shelljs = require('shelljs');
 let fext = require('file-extension');
 
 let Promise = require('bluebird');
@@ -74,7 +73,7 @@ module.exports = function videoCut(spec) {
 			duration: lastClipDuration.format(durationFormat, { trim: false })
 		});
 
-		return originalCuts;
+		return originalCuts.filter(cut => moment.duration(cut.duration).asMilliseconds() > 0);
 	}
 
 	/**

--- a/lib/videomerge.js
+++ b/lib/videomerge.js
@@ -1,7 +1,6 @@
 'use strict';
 
 let _ = require('lodash');
-let shelljs = require('shelljs');
 let fs = require('fs');
 let moment = require('moment');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -410,11 +410,6 @@
         "through": "~2.3.4"
       }
     },
-    "shelljs": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
-      "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM="
-    },
     "string.prototype.trim": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "lodash": ">=4.17.19",
     "moment": "^2.10.6",
     "moment-duration-format": "^1.3.0",
-    "shelljs": "^0.5.3",
     "tmp": "0.0.28"
   },
   "devDependencies": {

--- a/test/tailor.test.js
+++ b/test/tailor.test.js
@@ -5,8 +5,24 @@ let test = require('tape');
 let path = require('path');
 let videoStitch = require('../index');
 let util = require('util');
-let shelljs = require('shelljs');
-const ffmpeg = require('ffmpeg-static')
+let childProcess = require('child_process');
+const ffmpeg = process.env.FFMPEG_PATH || 'ffmpeg';
+const ffprobe = process.env.FFPROBE_PATH || 'ffprobe';
+
+function getDuration(fileName) {
+  return Number(childProcess.execFileSync(ffprobe, [
+    '-v', 'error',
+    '-show_entries', 'format=duration',
+    '-of', 'default=noprint_wrappers=1:nokey=1',
+    fileName
+  ], { encoding: 'utf8' }).trim());
+}
+
+test('Video Stitch imports without shelljs', (t) => {
+  t.plan(2);
+  t.ok(videoStitch, 'module imports');
+  t.notOk(require('../package.json').dependencies.shelljs, 'shelljs is not a runtime dependency');
+});
 
 test('Video Stitch Module', (t) => {
   let merger = videoStitch.merge;
@@ -62,10 +78,10 @@ test('Video Stitch Concat Module', (t) => {
   .concat()
   .then((outputFileName) => {
     t.pass(outputFileName);
-    let input1_duration = shelljs.exec(`ffmpeg -i "${path.join(__dirname, 'assets', 'tailor-5-10.mp4')}" 2>&1 | grep "Duration"| cut -d ' ' -f 4 | sed s/,// | sed 's@\\..*@@g' | awk '{ split($1, A, ":"); split(A[3], B, "."); print 3600*A[1] + 60*A[2] + B[1] }'`, { silent: true }).output;
-    let input2_duration = shelljs.exec(`ffmpeg -i "${path.join(__dirname, 'assets', 'tailor-20-25.mp4')}" 2>&1 | grep "Duration"| cut -d ' ' -f 4 | sed s/,// | sed 's@\\..*@@g' | awk '{ split($1, A, ":"); split(A[3], B, "."); print 3600*A[1] + 60*A[2] + B[1] }'`, { silent: true }).output;
-    let output_duration = shelljs.exec(`ffmpeg -i ${outputFileName} 2>&1 | grep "Duration"| cut -d ' ' -f 4 | sed s/,// | sed 's@\\..*@@g' | awk '{ split($1, A, ":"); split(A[3], B, "."); print 3600*A[1] + 60*A[2] + B[1] }'`, { silent: true }).output;
-    t.equal(parseInt(input1_duration) + parseInt(input2_duration), parseInt(output_duration));
+    let input1_duration = getDuration(path.join(__dirname, 'assets', 'tailor-5-10.mp4'));
+    let input2_duration = getDuration(path.join(__dirname, 'assets', 'tailor-20-25.mp4'));
+    let output_duration = getDuration(outputFileName);
+    t.ok(Math.abs(input1_duration + input2_duration - output_duration) < 0.1, 'output duration matches inputs');
   })
   .catch(err => {
     t.fail(util.inspect(err));
@@ -92,12 +108,35 @@ test('Video Stitch Concat Module - spaces in filepath', (t) => {
   .concat()
   .then((outputFileName) => {
     t.pass(outputFileName);
-    let input1_duration = shelljs.exec(`ffmpeg -i "${path.join(__dirname, 'assets', 'tailor-5-10.mp4')}" 2>&1 | grep "Duration"| cut -d ' ' -f 4 | sed s/,// | sed 's@\\..*@@g' | awk '{ split($1, A, ":"); split(A[3], B, "."); print 3600*A[1] + 60*A[2] + B[1] }'`, { silent: true }).output;
-    let input2_duration = shelljs.exec(`ffmpeg -i "${path.join(__dirname, 'assets', 'tailor-20 to 25.mp4')}" 2>&1 | grep "Duration"| cut -d ' ' -f 4 | sed s/,// | sed 's@\\..*@@g' | awk '{ split($1, A, ":"); split(A[3], B, "."); print 3600*A[1] + 60*A[2] + B[1] }'`, { silent: true }).output;
-    let output_duration = shelljs.exec(`ffmpeg -i ${outputFileName} 2>&1 | grep "Duration"| cut -d ' ' -f 4 | sed s/,// | sed 's@\\..*@@g' | awk '{ split($1, A, ":"); split(A[3], B, "."); print 3600*A[1] + 60*A[2] + B[1] }'`, { silent: true }).output;
-    t.equal(parseInt(input1_duration) + parseInt(input2_duration), parseInt(output_duration));
+    let input1_duration = getDuration(path.join(__dirname, 'assets', 'tailor-5-10.mp4'));
+    let input2_duration = getDuration(path.join(__dirname, 'assets', 'tailor-20 to 25.mp4'));
+    let output_duration = getDuration(outputFileName);
+    t.ok(Math.abs(input1_duration + input2_duration - output_duration) < 0.1, 'output duration matches inputs');
   })
   .catch(err => {
     t.fail(util.inspect(err));
   });
+});
+
+test('Video Cut excludes a segment that starts at 00:00:00', (t) => {
+  t.plan(3);
+  videoStitch.cut({ ffmpeg_path: ffmpeg })
+    .original({
+      fileName: path.join(__dirname, 'assets', 'tailor.mp4'),
+      duration: '00:00:30'
+    })
+    .exclude([{
+      startTime: '00:00:00',
+      duration: '00:00:05'
+    }])
+    .cut()
+    .then((clips) => {
+      t.equal(clips.length, 1, 'does not invoke ffmpeg for a zero-duration leading clip');
+      t.equal(clips[0].startTime, '00:00:05', 'remaining clip begins after excluded segment');
+      t.equal(clips[0].duration, '00:00:25', 'remaining clip covers the rest of the video');
+    })
+    .catch(err => {
+      t.fail(util.inspect(err));
+      t.end();
+    });
 });


### PR DESCRIPTION
## What changed

- remove the unused `shelljs` imports and runtime dependency
- replace shell-based test probing with direct `ffprobe` execution
- skip zero-duration generated cuts so exclusions beginning at `00:00:00` work
- add regression coverage for importing without `shelljs` and for zero-start exclusions

## Why

The obsolete `shelljs@0.5.3` runtime load breaks module imports on current Node.js, while the cut planner passed a zero-duration leading clip to FFmpeg when an excluded segment started at the beginning of a video.

This supersedes #19 and #27.

Closes #9.
Closes #16.

## Validation

- `npm test`: 10/10 passing with FFmpeg 8.0.1
- `npm ls shelljs --all`: empty
- `npm pack --dry-run --json`: successful
- `git diff --check`: clean
