### PR TITLE
Release v2.0.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "video-stitch",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "video-stitch",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "license": "ISC",
       "devDependencies": {
         "@eslint/js": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "video-stitch",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "Type-safe, secure video editing for Node.js powered by FFmpeg",
   "type": "module",
   "main": "./dist/cjs/index.js",


### PR DESCRIPTION
Publishes the first v2 prerelease through the repository's trusted npm release workflow.\n\nValidated locally with `npm run verify` on Node.js 26 and FFmpeg 8.0.1.