### PR TITLE
Fix npm 12 release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
         run: |
           mkdir release-assets
           npm pack --json --pack-destination release-assets > pack.json
-          filename="$(node -p "JSON.parse(require('fs').readFileSync('pack.json'))[0].filename")"
-          integrity="$(node -p "JSON.parse(require('fs').readFileSync('pack.json'))[0].integrity")"
+          filename="$(node -p "const result=JSON.parse(require('fs').readFileSync('pack.json'));(Array.isArray(result)?result[0]:Object.values(result)[0]).filename")"
+          integrity="$(node -p "const result=JSON.parse(require('fs').readFileSync('pack.json'));(Array.isArray(result)?result[0]:Object.values(result)[0]).integrity")"
           echo "filename=$filename" >> "$GITHUB_OUTPUT"
           echo "integrity=$integrity" >> "$GITHUB_OUTPUT"
           (cd release-assets && sha256sum "$filename" > SHA256SUMS.txt)

--- a/scripts/check-package.mjs
+++ b/scripts/check-package.mjs
@@ -8,7 +8,8 @@ const exec = promisify(execFile);
 const cache = join(tmpdir(), 'video-stitch-npm-cache');
 await mkdir(cache, { recursive: true });
 const { stdout } = await exec('npm', ['pack', '--dry-run', '--json', '--cache', cache]);
-const [pack] = JSON.parse(stdout);
+const packResult = JSON.parse(stdout);
+const pack = Array.isArray(packResult) ? packResult[0] : Object.values(packResult)[0];
 if (!pack) throw new Error('npm pack did not report a package');
 const forbidden = pack.files.filter(({ path }) => /^(src|test|scripts)\//u.test(path));
 if (forbidden.length > 0) {


### PR DESCRIPTION
Makes package metadata parsing compatible with both npm 11's array output and npm 12's keyed-object output. This resumes the unpublished v2.0.0-beta.1 release.\n\nValidated with npm 12.0.2 using `npm run pack:check:built`.