### PR TITLE
Fix npm 12 local release tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           fi
       - name: Publish exact tarball to npm or verify an idempotent rerun
         env:
-          PACKAGE: release-assets/${{ steps.pack.outputs.filename }}
+          PACKAGE: ./release-assets/${{ steps.pack.outputs.filename }}
         run: |
           version="${{ steps.release.outputs.version }}"
           expected="${{ steps.pack.outputs.integrity }}"


### PR DESCRIPTION
Prefixes the immutable release tarball with `./` so npm 12 treats it as a local package instead of GitHub shorthand. The v2.0.0-beta.1 package remains unpublished.\n\nValidated with npm 12.0.2 via a dry-run publish of the exact tarball path.